### PR TITLE
fix #166 #165 #163 #161

### DIFF
--- a/contracts/SecurityToken.sol
+++ b/contracts/SecurityToken.sol
@@ -156,7 +156,7 @@ contract SecurityToken is ISecurityToken, IERC20 {
      * @return bool success
      */
     function changeTotalSupply(uint256 _newTotalSupply) public onlyOwner returns (bool success) {
-      require(offering == 0x0);
+      require(offering == address(0));
       ChangeTotalSupply(totalSupply, _newTotalSupply);
       totalSupply = _newTotalSupply;
       balances[owner] = _newTotalSupply;
@@ -169,7 +169,7 @@ contract SecurityToken is ISecurityToken, IERC20 {
      * @return bool success
      */
     function changeDecimals(uint8 _newDecimals) public onlyOwner returns (bool success) {
-      require(offering == 0x0);
+      require(offering == address(0));
       ChangeDecimals(decimals, _newDecimals);
       decimals = _newDecimals;
       return true;
@@ -261,7 +261,7 @@ contract SecurityToken is ISecurityToken, IERC20 {
      */
     function initialiseOffering(uint256 _startTime, uint256 _endTime, uint256 _polyTokenRate, uint256 _maxPoly, uint256 _lockupPeriod, uint8 _quorum) onlyOwner external returns (bool success) {
         require(isOfferingFactorySet);
-        require(offering == 0x0);
+        require(offering == address(0));
         allocationStartTime = _startTime;
         require(_startTime > now && _endTime > _startTime);
         require(_lockupPeriod >= now);
@@ -345,7 +345,7 @@ contract SecurityToken is ISecurityToken, IERC20 {
      * @return bool success
      */
     function withdrawPoly() public returns (bool success) {
-      require(offering != 0x0);
+      require(offering != address(0));
       require(now > allocationStartTime.add(allocations[msg.sender].vestingPeriod));
       require(!allocations[msg.sender].frozen);
       require(allocations[msg.sender].amount > 0);
@@ -361,7 +361,7 @@ contract SecurityToken is ISecurityToken, IERC20 {
      */
     function voteToFreeze(address _recipient) public onlyShareholder returns (bool success) {
       require(delegate != address(0));
-      require(offering != 0x0);
+      require(offering != address(0));
       require(now > allocationStartTime);
       require(now < allocationStartTime.add(allocations[_recipient].vestingPeriod));
       require(!voted[msg.sender][_recipient]);
@@ -383,7 +383,7 @@ contract SecurityToken is ISecurityToken, IERC20 {
      */
     function issueSecurityTokens(address _contributor, uint256 _amountOfSecurityTokens, uint256 _polyContributed) public onlyOffering returns (bool success) {
       // Check whether the offering active or not
-      require(offering != 0x0);
+      require(offering != address(0));
       // The _contributor being issued tokens must be in the whitelist
       require(shareholders[_contributor].allowed);
       // In order to issue the ST, the _contributor first pays in POLY

--- a/contracts/Template.sol
+++ b/contracts/Template.sol
@@ -89,7 +89,7 @@ contract Template is ITemplate {
     }
 
     /**
-     * @dev `addJurisdiction` allows the adding of new jurisdictions to a template
+     * @dev `addDivisionJurisdiction` allows the adding of new jurisdictions to a template
      * @param _blockedDivisionJurisdictions An array of subdivision jurisdictions
      * @param _blocked An array of whether the subdivision jurisdiction is blocked to purchase the security or not
      */
@@ -103,7 +103,7 @@ contract Template is ITemplate {
     }
 
     /**
-     * @dev `addRole` allows the adding of new roles to be added to whitelist
+     * @dev `addRoles` allows the adding of new roles to be added to whitelist
      * @param _allowedRoles User roles that can purchase the security
      */
     function addRoles(uint8[] _allowedRoles) public {
@@ -177,7 +177,7 @@ contract Template is ITemplate {
     }
 
     /**
-     * @dev `getUsageFees` is a function to get all the details on template usage fees
+     * @dev `getUsageDetails` is a function to get all the details on template usage fees
      * @return uint256 fee, uint8 quorum, uint256 vestingPeriod, address owner, address KYC
      */
     function getUsageDetails() view public returns (uint256, uint8, uint256, address, address) {

--- a/test/SecurityToken.js
+++ b/test/SecurityToken.js
@@ -281,8 +281,10 @@ contract('SecurityToken', accounts => {
       // Create name space
       await STRegistrar.createNameSpace(
         nameSpaceMixed,
-        nameSpaceOwner,
-        nameSpaceFee
+        nameSpaceFee,
+        {
+          from: nameSpaceOwner,
+        }
       )
 
       // Creation of the Security Token with the help of SecurityTokenRegistrar contract


### PR DESCRIPTION
FYI - Check the lower functionality why we don't need the lower in the createSecurityToken()? also in test cases, it runs fine but when I did same for other functions as changeNameSpace and getNameSpaceData it gives me error so I add lower in both functions

`mapping (string => NameSpaceData) nameSpaceData` we can't make it public because of dynamic-sized variable so I make a getfunction for it